### PR TITLE
Allow a comma separated set of tag keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ your whole project with AllowTags just run `allowtags --allow-key key1 ./...`.
 ### Flags
 AllowTags requires all tags that it allows be explicitly given. To specify
 multiple tag keys pass the `--allow-key` flag multiple times, each time with a
-different tag key.
+different tag key, or separate different tag keys with a comma.
 
 ## Limitations
 AllowTags uses a different parsing method than govet and the golang standard

--- a/pkg/allowtags/allowtags.go
+++ b/pkg/allowtags/allowtags.go
@@ -348,7 +348,14 @@ func (tks *tagKeySet) String() string {
 }
 
 func (tks *tagKeySet) Set(value string) error {
-	*tks = append(*tks, value)
+	allValues := strings.Split(value, ",")
+
+	for _, val := range allValues {
+		if len(val) > 0 {
+			*tks = append(*tks, val)
+		}
+	}
+
 	return nil
 }
 
@@ -365,7 +372,8 @@ func New() *analysis.Analyzer {
 		&at.allowedKeys,
 		"allow-key",
 		//nolint:lll
-		"tag key name to allow. Pass the flag multiple times to allow multiple keys",
+		"tag key name to allow. Pass the flag multiple times or separate values"+
+			"with commas to specify multiple keys",
 	)
 
 	return &analysis.Analyzer{

--- a/pkg/allowtags/allowtags_test.go
+++ b/pkg/allowtags/allowtags_test.go
@@ -201,6 +201,29 @@ func (s *AllowTagsSuite) TestLint() {
 			inputTags:       "`json :\"field,omitempty\"`",
 			expectedMessage: "// want `invalid tag key character` ",
 		},
+		{
+			name: "CommaSeparatedKeys",
+			allowTags: []string{
+				"binary,json",
+			},
+			inputTags: "`json:\"field,omitempty\" binary:\"field\"`",
+		},
+		{
+			name: "CommaSeparatedKeys_EmptyKey",
+			allowTags: []string{
+				",json",
+			},
+			inputTags:       "`json:\"field,omitempty\" binary:\"field\"`",
+			expectedMessage: "// want `unknown tag key 'binary'`",
+		},
+		{
+			name: "CommaSeparatedKeysAndOtherKey",
+			allowTags: []string{
+				"binary,json",
+				"xml",
+			},
+			inputTags: "`json:\"field,omitempty\" binary:\"field\" xml:\"foo\"`",
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
Update flag parsing logic and README to allow comma separated tag keys on the CLI